### PR TITLE
refactor: 💡 deprecate docker dash compose

### DIFF
--- a/guides/Network nodes/fleek-network-running-a-node-in-a-docker-container.md
+++ b/guides/Network nodes/fleek-network-running-a-node-in-a-docker-container.md
@@ -127,18 +127,19 @@ Also, you'll be able to run it via the CLI, as such:
 ```sh
 docker -v
 ```
+
 ```
-Docker version 20.10.6, build 370c289
+Docker version 23.0.0, build e92dd87c32
 ```
 
-Let's do the same for `docker-compose`
-
-```sh
-docker-compose -v
-```
+Let's do the same for `docker compose`
 
 ```sh
-docker-compose version 1.29.1, build c34c88b2
+docker compose -v
+```
+
+```sh
+Docker version 23.0.0, build e92dd87c32
 ```
 
 💡 Versions might differ a bit from the time of writing.
@@ -565,7 +566,7 @@ Also, by using Docker compose it'll be easier to persist the configuration files
 
 ### Running a stack with Docker compose
 
-We have defined a Stack 🕸 that can be useful for running and monitoring; At time of writing, this is declared in a docker-compose file located [here](https://github.com/fleek-network/ursa/blob/cfbbe6208dc6a33d28b43c6e6820ab76c2905353/infra/ursa/docker-compose.yml).
+We have defined a Stack 🕸 that can be useful for running and monitoring; At time of writing, this is declared in a docker compose file located [here](https://github.com/fleek-network/ursa/blob/cfbbe6208dc6a33d28b43c6e6820ab76c2905353/infra/ursa/docker-compose.yml).
 
 There you'll find specified all the configuration options, such as the ones we've discussed in the previous topics about the host, port bindings, bind mount, etc. You don't have to constantly verify if specified all the correct options when running the Docker containers. Plus, we have these setup for you [grafana](https://grafana.com/), [prometheus](https://prometheus.io/docs/introduction/overview/), [certbot](https://certbot.eff.org/) and [nginx](https://www.nginx.com/). 
 
@@ -591,38 +592,24 @@ grafana uses an image, skipping
 
 💡 The `ursa` Docker image should be built every time you want to pull and use an update, learn how by following the guide [here](#fleek-network-how-to-get-the-latest-updates-for-ursa-cli-from-the-source-repository).
 
-In the project root, execute the docker-compose command by providing the `docker-compose.yml` configuration file and the subcommand up.
+In the project root, execute the docker compose command by providing the `docker-compose.yml` configuration file and the subcommand up.
 
 💩 If you are running the Docker daemon (not the Desktop version), BuildKit needs to be enabled, (desktop users have it enabled by default). Read our reference [BuildKit required by Docker build](../../reference/Docker/buildkit-required-by-docker-build) to learn more about how to enable it!
 
 ```sh
-docker-compose -f <DOCKER-COMPOSE-FILEPATH> <up | down>
+docker compose -f <DOCKER-COMPOSE-FILEPATH> <up | down>
 ```
 
 For our use-case, here's how it'll look like:
 
 ```sh
-docker-compose -f docker/full-node/docker-compose.yml up
+docker compose -f docker/full-node/docker-compose.yml up
 ```
 
 Where for stopping, you have option `down`:
 
 ```sh
-docker-compose -f docker/full-node/docker-compose.yml down
-```
-
-Also, we provide the following utility commands for your convenience.
-
-A command to execute the docker compose up:
-
-```sh
-make compose-up
-```
-
-Also, to execute the docker compose down:
-
-```sh
-make compose-down
+docker compose -f docker/full-node/docker-compose.yml down
 ```
 
 Here, we have an opinionated stack that you can use as a base for your system, or as a reference, for your research and learning. This means you aren't obligated to use Grafana or Prometheus. Ursa works without any dependency!

--- a/reference/Docker/buildkit-required-by-docker-build.md
+++ b/reference/Docker/buildkit-required-by-docker-build.md
@@ -30,7 +30,7 @@ DOCKER_BUILDKIT=1
 Here's the complete prefixed command
 
 ```sh
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker/full-node/docker-compose.yml up -d
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker/full-node/docker-compose.yml up -d
 ```
 
 Docker desktop users don't have to has its enabled by default default.

--- a/reference/Docker/docker-compose-use-latest-image-instead-of-building.md
+++ b/reference/Docker/docker-compose-use-latest-image-instead-of-building.md
@@ -2,7 +2,7 @@
 template: post
 draft: false
 hide_title: false
-title: Docker-compose use latest image instead of building
+title: Docker compose use latest image instead of building
 slug: docker-compose-use-latest-image-instead-of-building
 date: 2023-02-09T31:00:00Z
 canonical: ''
@@ -10,7 +10,7 @@ description: Quick reference on how to use the latest image instead of building
 category: Reference
 tags:
 - Reference
-- docker-compose
+- docker compose
 - Fleek Network
 - build
 - latest
@@ -52,33 +52,33 @@ Change directory to ursa root, e.g., by default is `$HOME/fleek-network/ursa`.
 Stop the Stack
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml stop
+docker compose -f ./docker/full-node/docker-compose.yml stop
 ```
 
 Remove stopped containers
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml rm
+docker compose -f ./docker/full-node/docker-compose.yml rm
 ```
 
 Pull the latest images e.g., Ursa's `latest`
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml pull
+docker compose -f ./docker/full-node/docker-compose.yml pull
 ```
 
 Start the Stack
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml up
+docker compose -f ./docker/full-node/docker-compose.yml up
 ```
 
 Most users find that is enough to do (you have to restart the service)
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml pull
+docker compose -f ./docker/full-node/docker-compose.yml pull
 ```
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml up
+docker compose -f ./docker/full-node/docker-compose.yml up
 ```

--- a/reference/Docker/services-authentication.md
+++ b/reference/Docker/services-authentication.md
@@ -20,13 +20,13 @@ tags:
 - admin
 ---
 
-The Docker-compose stack configuration files have some services declared for monitoring and analytics. You might be interested in accessing the dashboard of these services, which you can do by requesting via a hostname and port number where the service is listening to.
+The Docker compose stack configuration files have some services declared for monitoring and analytics. You might be interested in accessing the dashboard of these services, which you can do by requesting via a hostname and port number where the service is listening to.
 
-Our Docker-compose stack configuration is located at `$HOME/fleek-network/ursa/docker/full-node/docker-compose.yml` by default.
+Our Docker compose stack configuration is located at `$HOME/fleek-network/ursa/docker/full-node/docker-compose.yml` by default.
 
 There, you can check which services are declared and the port numbers they're accessible from and the access detail settings.
 
-When launching the Docker-compose stack, you'll see that the admin user and password details are blank.
+When launching the Docker compose stack, you'll see that the admin user and password details are blank.
 
 ```sh
 WARNING: The ADMIN_USER variable is not set. Defaulting to a blank string.
@@ -65,7 +65,7 @@ ADMIN_USER=fleek
 ADMIN_PASSWORD=oiG!s@s_3Az
 ```
 
-Launch the Docker-compose stack (if running, use `down` and then after `up`).
+Launch the Docker compose stack (if running, use `down` and then after `up`).
 
 Our example shows the `up` version.
 

--- a/reference/Docker/update-latest-stack-images.md
+++ b/reference/Docker/update-latest-stack-images.md
@@ -52,33 +52,33 @@ Change directory to ursa, e.g., by default is `$HOME/fleek-network/ursa` (you ma
 Stop the Stack
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml stop
+docker compose -f ./docker/full-node/docker-compose.yml stop
 ```
 
 Remove stopped containers
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml rm
+docker compose -f ./docker/full-node/docker-compose.yml rm
 ```
 
 Pull the latest images e.g., Ursa's `latest`
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml pull
+docker compose -f ./docker/full-node/docker-compose.yml pull
 ```
 
 Start the Stack
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml up
+docker compose -f ./docker/full-node/docker-compose.yml up
 ```
 
 Most users find that is enough to do (you have to restart the service)
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml pull
+docker compose -f ./docker/full-node/docker-compose.yml pull
 ```
 
 ```sh
-docker-compose -f ./docker/full-node/docker-compose.yml up
+docker compose -f ./docker/full-node/docker-compose.yml up
 ```

--- a/reference/Ursa-CLI/stop-the-fleek-network-node-process.md
+++ b/reference/Ursa-CLI/stop-the-fleek-network-node-process.md
@@ -18,7 +18,7 @@ tags:
 Stop the Fleek Network node for Docker
 
 ```sh
-docker-compose -f docker/full-node/docker-compose.yml down
+docker compose -f docker/full-node/docker-compose.yml down
 ```
 
 Stop the Fleek Network node by sending a terminate signal (SIGTERM) to the `ursa` process


### PR DESCRIPTION
## Why?

Deprecated docker-compose

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content is linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
