### PR TITLE
chore: 🤖 Update testnet onboarding guide to reflect phase 1

### DIFF
--- a/docs/node/testnet-onboarding.md
+++ b/docs/node/testnet-onboarding.md
@@ -12,22 +12,22 @@ sidebarCollapsible: false
 
 ## Testnet Onboarding
 
+Currently, we are for accepting early applications for node operators interested in joining Phase {1} of Fleek Network's testnet. Submissions are open early, before the Phases' release, and will be approved close to its release.
+
 1. Join our [Discord](https://discord.gg/fleekxyz) server
     
   a) To get onboarded, go to the `Fleek Network Nodes` section and follow the instructions in the **#access-guide** channel
 
 2. Learn about the [required server specifications](/docs/node/requirements) on which the Fleek Network Node can be installed and run.
 
-3. Follow the [instructions](/docs/node/install) to install the node via the [assisted installer](/docs/node/install#assisted-installer) (easy) or [manually](/docs/node/install#manual-installation) (advanced).
-
-4. In our [Discord](https://discord.gg/fleekxyz) server, visit **#access-form,** run the node commands, and submit the information in the form.
+3. In our [Discord](https://discord.gg/fleekxyz) server, visit **#access-form,**, and submit the information in the form.
 
 :::caution Important
 Live information should be checked in the Fleek Network 
 [node announcements](https://discord.com/channels/965698989464887386/1148719641896693873) Discord channel. Due to the number of requests and to improve the onboarding experience, the channel or forms might have offline periods. Check the [node announcements](https://discord.com/channels/965698989464887386/1148719641896693873) for live updates, please!
 :::
 
-5. The team will review your application, allowing/listing your node if approved
+4. The team will review your application, allowing/listing your node if approved
 
 :::info
 When approved, you will be notified in the **#access-approved** channel on Discord and given the Node Operator role.
@@ -37,11 +37,10 @@ When approved, you will be notified in the **#access-approved** channel on Disco
 
 - All announcements for node operators will be sent to **#node-announcements**
 - You can ask for help in **#troubleshooting**, or chat with the team in the **#node-operators** channel
-- Every Friday at 3 pm EST, we will conduct Node Community Calls in **#node-stage**
 
 ## Node whitelist verification
 
-You might find it useful to run the following command to verify the status of the node whitelist status–since a node throws an error if not whitelisted, this can be verified by looking at and monitoring the `diagnostic.log` file manually, otherwise, use the method shared here.
+Important: This guides are valid during an active testnet phase. You might find it useful to run the following command to verify the status of the node whitelist status–since a node throws an error if not whitelisted, this can be verified by looking at and monitoring the `diagnostic.log` file manually, otherwise, use the method shared here.
 
 1) Connect to the server terminal where the node is installed
 


### PR DESCRIPTION
## Why?

To match current information on the new upcoming blog.

## How?

Reduced information available in the node onboarding page.
