### PR TITLE
fix: 🐛 Fix whitepaper link

### DIFF
--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -21,4 +21,4 @@ The whitepaper outlines the technology that makes the Fleek Network Edge Computi
 
 The latest whitepaper is available on this page, and it describes the protocol architecture, general operation, and characteristics.
 
-- [Read the Whitepaper](https://whitepaper.fleek.network/)
+- [Read the Whitepaper](https://fleek.network/whitepaper.pdf)


### PR DESCRIPTION
## Why?

Fix the whitepaper link. Currently it points to https://whitepaper.fleek.network/ instead of https://fleek.network/whitepaper.pdf.

## How?

- See above

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content is linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [N/A] Injection has been prevented (parameterized queries, no eval or system calls)
- [N/A] The UI is escaping output (to prevent XSS)
- [N/A] Sensitive data has been identified and is being protected properly

