### PR TITLE
docs: 📝 Remove deprecated yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The Fleek Network documentation and guides source.
 ### 🤖 Installation
 
 ```
-yarn
+npm i
 ```
 
 ### 🏠 Local Development
 
 ```
-yarn start
+npm run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -22,7 +22,7 @@ This command starts a local development server and opens up a browser window. Mo
 ### 👷 Build
 
 ```
-yarn build
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -44,7 +44,7 @@ Any new commit into the `main` branch will trigger the [Deploy (Github pages)](h
 Alternatively, to publish manually to `gh_pages` use the `deploy` command. Here we prefix the command with the optional variables.
 
 ```sh
-USE_SSH=true GIT_USER=<Your github username> yarn deploy
+USE_SSH=true GIT_USER=<Your github username> npm run deploy
 ```
 
 💡 The command requires you to have Git authenticated via ssh.
@@ -76,7 +76,7 @@ API_KEY=<YOUR API KEY>
 Then you need to start the crawl according to your configuration.
 
 ```
-yarn crawl:docker
+npm run crawl:docker
 ```
 
 ### 👩‍🎨 Custom domain


### PR DESCRIPTION
## Why?

Remove deprecated yarn command, inherited from Psychedelic org "docta" project.

## How?

- Remove "yarn"

## Tickets?

- [PLAT-1937](https://linear.app/fleekxyz/issue/PLAT-1937/remove-deprecated-yarn-command)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content is linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
